### PR TITLE
Auto-refresh default images every week and upon version upgrade

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -75,6 +75,7 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "log-symbols": {
@@ -114,6 +115,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "spinners": {
@@ -180,6 +182,7 @@
                 "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
                 "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.10"
         },
         "websocket-client": {
@@ -218,6 +221,7 @@
                 "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
                 "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.0"
         },
         "black": {
@@ -270,6 +274,7 @@
                 "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
                 "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.16"
         },
         "filelock": {
@@ -292,6 +297,7 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "imagesize": {
@@ -299,6 +305,7 @@
                 "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
                 "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
         },
         "importlib-metadata": {
@@ -322,6 +329,7 @@
                 "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
                 "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.11.2"
         },
         "livereload": {
@@ -366,6 +374,7 @@
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
                 "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
         "mccabe": {
@@ -387,6 +396,7 @@
                 "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
                 "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.4"
         },
         "pathspec": {
@@ -407,6 +417,7 @@
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
         "port-for": {
@@ -420,6 +431,7 @@
                 "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
                 "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.9.0"
         },
         "pycodestyle": {
@@ -427,6 +439,7 @@
                 "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
                 "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.6.0"
         },
         "pyflakes": {
@@ -434,6 +447,7 @@
                 "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
                 "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
         },
         "pygments": {
@@ -441,6 +455,7 @@
                 "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
                 "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==2.6.1"
         },
         "pyparsing": {
@@ -448,6 +463,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytz": {
@@ -513,6 +529,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "snowballstemmer": {
@@ -543,6 +560,7 @@
                 "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a",
                 "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.2"
         },
         "sphinxcontrib-devhelp": {
@@ -550,6 +568,7 @@
                 "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e",
                 "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.2"
         },
         "sphinxcontrib-htmlhelp": {
@@ -557,6 +576,7 @@
                 "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f",
                 "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.3"
         },
         "sphinxcontrib-jsmath": {
@@ -564,6 +584,7 @@
                 "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
                 "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.1"
         },
         "sphinxcontrib-qthelp": {
@@ -571,6 +592,7 @@
                 "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72",
                 "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.3"
         },
         "sphinxcontrib-serializinghtml": {
@@ -578,6 +600,7 @@
                 "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc",
                 "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.1.4"
         },
         "toml": {
@@ -599,6 +622,7 @@
                 "sha256:c952975c8ba74f546ae6de2e226ab3cc3cc11ae47baf607459a6728585bb542a",
                 "sha256:c98232a3ac391f5faea6821b53db8db461157baa788f5d6222a193e9456e1740"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==6.0.4"
         },
         "tox": {
@@ -648,6 +672,7 @@
                 "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
                 "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.10"
         },
         "virtualenv": {
@@ -655,6 +680,7 @@
                 "sha256:43add625c53c596d38f971a465553f6318decc39d98512bc100fa1b1e839c8dc",
                 "sha256:e0305af10299a7fb0d69393d8f04cb2965dda9351140d11ac8db4e5e3970451b"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.0.31"
         },
         "watchdog": {

--- a/wilfred/api/images.py
+++ b/wilfred/api/images.py
@@ -155,6 +155,7 @@ class Images(object):
 
         self.image_fetch_date = "N/A"
         self.image_fetch_version = "N/A"
+        self.image_time_to_refresh = "N/A"
 
         try:
             with open(f"{self.config_dir}/image_cache.json") as f:
@@ -164,6 +165,9 @@ class Images(object):
                     data["time"], "%Y-%m-%d %H:%M:%S.%f"
                 )
                 self.image_fetch_version = data["version"]
+                self.image_time_to_refresh = timedelta(days=7) - (
+                    datetime.now() - self.image_fetch_date
+                )
         except Exception:
             pass
 

--- a/wilfred/api/images.py
+++ b/wilfred/api/images.py
@@ -12,14 +12,16 @@ import json
 
 from appdirs import user_config_dir
 from pathlib import Path
-from os.path import isdir, join
+from os.path import isdir, join, isfile
 from os import walk, remove
 from requests import get
 from zipfile import ZipFile
 from shutil import move, rmtree
 from copy import deepcopy
+from datetime import datetime, timedelta
 
 from wilfred.errors import WilfredException, ReadError, ParseError
+from wilfred.version import version
 
 API_VERSION = 2
 
@@ -34,6 +36,10 @@ class ImagesNotRead(WilfredException):
 
 class ImageAPIMismatch(WilfredException):
     """API level of image and API level of Wilfred mismatch"""
+
+
+class ImagesOutdated(WilfredException):
+    """Wilfred images are outdated and require refresh"""
 
 
 class Images(object):
@@ -71,6 +77,12 @@ class Images(object):
 
         remove(f"{self.config_dir}/img.zip")
         rmtree(f"{self.config_dir}/temp_images")
+
+        # write to cache info that images have been updated
+        data = {"time": str(datetime.now()), "version": version}
+
+        with open(f"{self.config_dir}/image_cache.json", "w") as f:
+            json.dump(data, f)
 
     def data_strip_non_ui(self):
         """
@@ -138,6 +150,23 @@ class Images(object):
         if not self.check_if_present():
             raise ImagesNotPresent("Default images not present")
 
+        if self.is_outdated():
+            raise ImagesOutdated("Images are outdated, refresh required")
+
+        self.image_fetch_date = "N/A"
+        self.image_fetch_version = "N/A"
+
+        try:
+            with open(f"{self.config_dir}/image_cache.json") as f:
+                data = json.load(f)
+
+                self.image_fetch_date = datetime.strptime(
+                    data["time"], "%Y-%m-%d %H:%M:%S.%f"
+                )
+                self.image_fetch_version = data["version"]
+        except Exception:
+            pass
+
         self.images = []
 
         for root, dirs, files in walk(self.image_dir):
@@ -176,6 +205,29 @@ class Images(object):
             return False
 
         return True
+
+    def is_outdated(self):
+        """Checks if default images are outdated"""
+
+        if not isfile(f"{self.config_dir}/image_cache.json"):
+            return True
+
+        try:
+            with open(f"{self.config_dir}/image_cache.json") as f:
+                data = json.load(f)
+
+                if (
+                    datetime.now()
+                    - datetime.strptime(data["time"], "%Y-%m-%d %H:%M:%S.%f")
+                ) > timedelta(days=7):
+                    return True
+
+                if data["version"] != version:
+                    return True
+
+                return False
+        except Exception:
+            return True
 
     def _verify(self, image: dict, file: str):
         def _exception(key):

--- a/wilfred/wilfred.py
+++ b/wilfred/wilfred.py
@@ -278,8 +278,15 @@ def list_images(refresh):
         )
     )
 
+    updated_at = click.style(
+        images.image_fetch_date.strftime("%Y-%m-%d %H:%M:%S"), bold=True
+    )
+    will_refresh_in = click.style(
+        str(images.image_time_to_refresh).split(".")[0], bold=True
+    )
+
     click.echo(
-        f"Default images last updated at {str(images.image_fetch_date)} with Wilfred version {images.image_fetch_version}"
+        f"Default images last updated at {updated_at}, will refresh in {will_refresh_in}"
     )
 
 


### PR DESCRIPTION
* The date of download is saved when default images are downloaded. Every time Wilfred runs, it will check if a week has passed since that date. If so it will trigger a refresh
* Wilfred version is saved when default images are downloaded. If a newer version of Wilfred is then running, it will trigger an image refresh

Fixes #74 
