### PR TITLE
Add ability to specify repo and branch on "wilfred images --refresh"

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -33,10 +33,11 @@
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
         },
         "click": {
             "hashes": [
@@ -106,11 +107,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8",
-                "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
             "index": "pypi",
-            "version": "==2.25.0"
+            "version": "==2.25.1"
         },
         "six": {
             "hashes": [
@@ -241,10 +242,11 @@
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
         },
         "click": {
             "hashes": [
@@ -393,11 +395,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:05af3bb85d320377db281cf254ab050e1a7ebcbf5410685a9a407e18a1f81236",
-                "sha256:eb41423378682dadb7166144a4926e443093863024de508ca5c9737d6bc08376"
+                "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858",
+                "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.7"
+            "version": "==20.8"
         },
         "pathspec": {
             "hashes": [
@@ -416,11 +418,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
-                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.9.0"
+            "version": "==1.10.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -509,11 +511,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8",
-                "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
             "index": "pypi",
-            "version": "==2.25.0"
+            "version": "==2.25.1"
         },
         "six": {
             "hashes": [

--- a/wilfred/api/images.py
+++ b/wilfred/api/images.py
@@ -53,7 +53,7 @@ class Images(object):
         if not isdir(self.image_dir):
             Path(self.image_dir).mkdir(parents=True, exist_ok=True)
 
-    def download(self):
+    def download(self, branch="master", repo="wilfred-dev/images"):
         """
         Downloads default Wilfred Images from GitHub
         """
@@ -62,7 +62,7 @@ class Images(object):
 
         with open(f"{self.config_dir}/img.zip", "wb") as f:
             response = get(
-                "https://github.com/wilfred-dev/images/archive/master.zip",
+                f"https://github.com/{repo}/archive/{branch}.zip",
                 stream=True,
             )
             f.write(response.content)
@@ -71,7 +71,7 @@ class Images(object):
             obj.extractall(f"{self.config_dir}/temp_images")
 
         move(
-            f"{self.config_dir}/temp_images/images-master/images",
+            f"{self.config_dir}/temp_images/images-{branch}/images",
             f"{self.image_dir}/default",
         )
 

--- a/wilfred/wilfred.py
+++ b/wilfred/wilfred.py
@@ -255,19 +255,33 @@ def servers_list():
 
 @cli.command("images")
 @click.option("--refresh", help="Download the default images from GitHub", is_flag=True)
-def list_images(refresh):
+@click.option(
+    "--repo",
+    help="Specify repo to fetch images from during image refresh",
+    default="wilfred-dev/images",
+    show_default=True,
+)
+@click.option(
+    "--branch",
+    help="Specify branch to fetch images from during image refresh",
+    default="master",
+    show_default=True,
+)
+def list_images(refresh, repo, branch):
     """List images available on file."""
 
     if refresh:
-        with Halo(text="Refreshing images", color="yellow", spinner="dots") as spinner:
+        with Halo(
+            text=f"Refreshing images [{repo}/{branch}]", color="yellow", spinner="dots"
+        ) as spinner:
             try:
-                images.download()
+                images.download(repo=repo, branch=branch)
                 images.read_images()
             except Exception as e:
                 spinner.fail()
                 ui_exception(e)
 
-            spinner.succeed("Images refreshed")
+            spinner.succeed(f"Images refreshed [{repo}/{branch}]")
 
     click.echo(
         tabulate(


### PR DESCRIPTION
* using `--branch` you can now set Wilfred to fetch it's default images from another branch than `master`
* using `--repo` you can now set Wilfred to fetch it's default images from another repo than `wilfred-dev/images`

e.g. I have a fork on `vilhelmprytz/images` and I've been working on images in the branch `patch-1`. I can tell Wilfred to fetch images from here by running `wilfred images --refresh --repo vilhelmprytz/images --branch patch-1`

Fixes #86


<!-- include the issue number if this pull request is fixing that issue -->
