### PR TITLE
api/servers: handle no stats available better

### DIFF
--- a/wilfred/api/servers.py
+++ b/wilfred/api/servers.py
@@ -66,6 +66,7 @@ class Servers(object):
             if cpu_load or memory_usage:
                 for server in servers:
                     _running = True
+                    _stats_avail = True
 
                     try:
                         container = self._docker_client.containers.get(
@@ -82,6 +83,15 @@ class Servers(object):
                         _running = False
 
                     if cpu_load and _running:
+                        # on some systems, statisics are not available
+                        if (
+                            "system_cpu_usage" not in d["cpu_stats"]
+                            or "system_cpu_usage" not in d["precpu_stats"]
+                        ):
+                            server.update({"cpu_load": "-"})
+                            _stats_avail = False
+
+                    if cpu_load and _running and _stats_avail:
                         # calculate the change in CPU usage between current and previous reading
                         cpu_delta = float(
                             d["cpu_stats"]["cpu_usage"]["total_usage"]


### PR DESCRIPTION
when systemd.unified_cgroup_hierarchy=1 is missing from /etc/default/grub,
some statistics are required when displaying CPU and mem usage in wilfred top
will be missing, causing wilfred to crash

